### PR TITLE
Fix(tts): streaming writer should use StreamTTS

### DIFF
--- a/client.go
+++ b/client.go
@@ -861,7 +861,7 @@ func (c *Client) TTS(text string, speaker string, playID string, endOfStream, au
 }
 
 // TTS sends a text-to-speech command
-func (c *Client) StreamTTS(text string, speaker string, playID string, autoHangup, endOfStream bool, option *TTSOption, waitInputTimeout *uint32) error {
+func (c *Client) StreamTTS(text string, speaker string, playID string, endOfStream, autoHangup bool, option *TTSOption, waitInputTimeout *uint32) error {
 	cmd := TtsCommand{
 		Command:          "tts",
 		Text:             text,

--- a/cmd/llm.go
+++ b/cmd/llm.go
@@ -102,18 +102,12 @@ func NewStreamingTTSWriter(client *rustpbxgo.Client, playID string, logger *logr
 
 func (w *StreamingTTSWriter) Write(delta string, endOfStream, autoHangup bool) error {
 	// Don't send empty content unless it's specifically needed for endOfStream signaling
-	// For streaming mode, only send if there's actual content or if it's an endOfStream signal with content
-	if delta == "" && !endOfStream {
+	// For streaming mode, only send if there's actual content or if it's an endOfStream signal with conten
+	if delta == "" {
 		return nil
 	}
 
-	// For endOfStream with no content, skip the TTS call since there's nothing to say
-	if delta == "" && endOfStream {
-		w.logger.Debug("Skipping empty endOfStream TTS call in streaming mode")
-		return nil
-	}
-
-	return w.client.TTS(delta, "", w.playID, endOfStream, autoHangup, nil, nil)
+	return w.client.StreamTTS(delta, "", w.playID, endOfStream, autoHangup, nil, nil)
 }
 
 func (w *StreamingTTSWriter) GetPlayID() string {


### PR DESCRIPTION
- swapping order of two parameter in StreamTTS, make it consistent with TTS
- use StreamTTS in stead of TTS for StreamingTTSWriter